### PR TITLE
Ignore non-primary variations when parsing bestmove

### DIFF
--- a/pystockfish.py
+++ b/pystockfish.py
@@ -212,6 +212,10 @@ class Engine(subprocess.Popen):
                         'ponder': split_text[3],
                         'info': last_line
                         }
+                if 'multipv' not in split_text:
+                    continue
+                if split_text[split_text.index('multipv') + 1] != '1':
+                    continue
             last_line = text
 
     def parse_info(self, info):


### PR DESCRIPTION
Before this PR the "bestmove" method would return the _least primary_ variation info (e.g. if you specified "MultiPV" to be 10, engine.bestmove()["info"] would have the 10th variation, rather than the 1st variation).